### PR TITLE
Minor table fixes

### DIFF
--- a/client/src/components/ColumnHeaderHelper.tsx
+++ b/client/src/components/ColumnHeaderHelper.tsx
@@ -45,7 +45,7 @@ export const HEADER_COMPONENT: {[id: string] : JSX.Element} = {
     [ColumnId.PERCENT_BIALLELIC]: (
         <ColumnHeader
             headerContent={<span className="pull-right mr-3">% Biallelic <i className="fa fa-info-circle" /></span>}
-            overlay={<span>Percent of pathogenic germline carriers biallelic in the corresponding tumor</span>}
+            overlay={<span>Percent of pathogenic germline carriers biallelic in the corresponding tumor sample</span>}
         />
     ),
     [ColumnId.MUTATION_PERCENT]: <ColumnHeader headerContent={<span className="pull-right mr-3">%</span>} />,

--- a/client/src/components/GeneTumorTypeFrequencyTable.tsx
+++ b/client/src/components/GeneTumorTypeFrequencyTable.tsx
@@ -68,6 +68,13 @@ class GeneTumorTypeFrequencyTable extends React.Component<ITumorTypeFrequencyTab
                             minWidth: 250
                         },
                         {
+                            id: ColumnId.SAMPLE_COUNT,
+                            Cell: renderCount,
+                            Header: HEADER_COMPONENT[ColumnId.SAMPLE_COUNT],
+                            accessor: ColumnId.SAMPLE_COUNT,
+                            maxWidth: 80
+                        },
+                        {
                             id: ColumnId.GERMLINE,
                             Cell: renderPercentage,
                             Header: HEADER_COMPONENT[ColumnId.GERMLINE],
@@ -87,13 +94,6 @@ class GeneTumorTypeFrequencyTable extends React.Component<ITumorTypeFrequencyTab
                             Header: HEADER_COMPONENT[ColumnId.SOMATIC_DRIVER],
                             accessor: somaticAccessor,
                             maxWidth: 120
-                        },
-                        {
-                            id: ColumnId.SAMPLE_COUNT,
-                            Cell: renderCount,
-                            Header: HEADER_COMPONENT[ColumnId.SAMPLE_COUNT],
-                            accessor: ColumnId.SAMPLE_COUNT,
-                            maxWidth: 80
                         }
                     ]}
                     defaultSorted={[{

--- a/client/src/components/MutationMapper.tsx
+++ b/client/src/components/MutationMapper.tsx
@@ -179,6 +179,12 @@ class MutationMapper extends React.Component<IMutationMapperProps>
                         Header: HEADER_COMPONENT[ColumnId.MUTATION_PERCENT]
                     },
                     {
+                        expander: true,
+                        Expander: this.renderExpander,
+                        togglable: false,
+                        width: 25
+                    },
+                    {
                         id: ColumnId.PERCENT_BIALLELIC,
                         name: "% Biallelic",
                         Cell: renderPercentage,
@@ -192,13 +198,7 @@ class MutationMapper extends React.Component<IMutationMapperProps>
                     MUTATION_COLUMNS_DEFINITION[MutationColumn.START_POSITION],
                     MUTATION_COLUMNS_DEFINITION[MutationColumn.END_POSITION],
                     MUTATION_COLUMNS_DEFINITION[MutationColumn.REFERENCE_ALLELE],
-                    MUTATION_COLUMNS_DEFINITION[MutationColumn.VARIANT_ALLELE],
-                    {
-                        expander: true,
-                        Expander: this.renderExpander,
-                        togglable: false,
-                        width: 25
-                    }
+                    MUTATION_COLUMNS_DEFINITION[MutationColumn.VARIANT_ALLELE]
                 ]}
                 customMutationTableProps={{
                     SubComponent: this.renderSubComponent

--- a/client/src/components/MutationStatusSelector.tsx
+++ b/client/src/components/MutationStatusSelector.tsx
@@ -20,7 +20,7 @@ export const MUTATION_RATE_HELPER = {
     },
     [MutationStatusFilterValue.BIALLELIC_PATHOGENIC_GERMLINE]: {
         title: "Biallelic Pathogenic Germline",
-        description: "Percent of pathogenic germline carriers biallelic in the corresponding tumor"
+        description: "Percent of pathogenic germline carriers biallelic in the corresponding tumor sample"
     }
 };
 


### PR DESCRIPTION
- Moved `# Samples` right after `Tumor Type` column for the expanded table in home page
- Updated `% Biallelic` info text
- Moved expander right next to the `%` column for the table in the gene page 