### PR TITLE
Prevented filters from updating their own counts when checked

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
     "react": "^16.8.6",
     "react-bootstrap": "^1.0.0-beta.6",
     "react-dom": "^16.8.6",
-    "react-mutation-mapper": "0.3.0-beta.8",
+    "react-mutation-mapper": "0.3.0-beta.9",
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.3.1",
     "react-scripts-ts": "3.1.0",

--- a/client/src/components/InsightMutationMapper.tsx
+++ b/client/src/components/InsightMutationMapper.tsx
@@ -3,6 +3,7 @@ import {action, computed, observable} from "mobx";
 import {observer} from "mobx-react";
 import * as React from 'react';
 import {
+    applyDataFilters,
     DataFilterType,
     FilterResetPanel,
     MutationMapper as ReactMutationMapper,
@@ -266,7 +267,13 @@ export class InsightMutationMapper extends ReactMutationMapper<IInsightMutationM
             values: [MutationStatusFilterValue.BIALLELIC_PATHOGENIC_GERMLINE]
         };
 
-        const sortedFilteredData = this.store.dataStore.sortedFilteredData;
+        const filtersWithoutMutationStatusFilter =
+            this.store.dataStore.dataFilters.filter(f => f.id !== MUTATION_STATUS_FILTER_ID);
+
+        // apply filters excluding the mutation status filter
+        // this prevents ratio of unchecked mutation status values from being calculated as zero
+        const sortedFilteredData = applyDataFilters(
+            this.store.dataStore.allData, filtersWithoutMutationStatusFilter, this.store.dataStore.applyFilter);
 
         const somaticFrequency = calculateTotalFrequency(
             sortedFilteredData, somaticFilter, this.cancerTypeFilter);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7762,10 +7762,10 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-mutation-mapper@0.3.0-beta.8:
-  version "0.3.0-beta.8"
-  resolved "https://registry.yarnpkg.com/react-mutation-mapper/-/react-mutation-mapper-0.3.0-beta.8.tgz#fcdf5968cf5fccf2900eb86bffc02350dd9e929b"
-  integrity sha512-Ns+f7FeRkZl6RWfZ+g71C61PxJfdzMcZfcdK6nbQm6BzHvIc9EqNOi9EnqwPUoTY1rVQ7i060DlqwWs6y19I6A==
+react-mutation-mapper@0.3.0-beta.9:
+  version "0.3.0-beta.9"
+  resolved "https://registry.yarnpkg.com/react-mutation-mapper/-/react-mutation-mapper-0.3.0-beta.9.tgz#837f01dc646c6c536048dcf850a5ce8817069c32"
+  integrity sha512-h63RpFd4AacbVKdWOnnD0fO9L3iy1SexhSIDhO4NG4oFsUiAzz/iNn1Igp8OIi7JSLZO2m90L8ng8wIylUc6Tw==
   dependencies:
     autobind-decorator "^2.4.0"
     cbioportal-frontend-commons "^0.0.23"


### PR DESCRIPTION
![filter_counts](https://user-images.githubusercontent.com/3604198/66767019-80c18680-ee7d-11e9-94bb-0c3dbaf84925.png)

- Checking/unchecking a mutation status filter option updates mutation type counts, but not Mutation Status rates
- Checking/unchecking a mutation type filter option updates mutation status rates, but not mutation type counts
 