### PR TITLE
Removed font size style for the inner circled letter content

### DIFF
--- a/src/components/CircledLetter.tsx
+++ b/src/components/CircledLetter.tsx
@@ -12,7 +12,7 @@ class CircledLetter extends React.Component<ICircledLetterProps>
         return (
             <span className="fa-stack" style={{fontSize: "0.5rem"}}>
                 <i className="fa fa-circle fa-stack-2x" style={{color: this.props.color}}/>
-                <strong className="fa-stack-1x fa-inverse" style={{fontSize: "0.6rem"}}>{this.props.letter}</strong>
+                <strong className="fa-stack-1x fa-inverse">{this.props.letter}</strong>
             </span>
         )
     }


### PR DESCRIPTION
Current styling of the penetrance column doesn't align well in Firefox

Before fix:
![penetrance_misaligned](https://user-images.githubusercontent.com/3604198/72852106-9a901800-3c7b-11ea-929e-6837d4aa43f5.png)

After fix:
![penetrance_aligned](https://user-images.githubusercontent.com/3604198/72852119-a7ad0700-3c7b-11ea-86d7-b59ef06edda6.png)
